### PR TITLE
Dark frame

### DIFF
--- a/frameProcessor/include/LATRDProcessPlugin.h
+++ b/frameProcessor/include/LATRDProcessPlugin.h
@@ -57,6 +57,7 @@ namespace FrameProcessor {
         int get_version_patch();
         std::string get_version_short();
         std::string get_version_long();
+        unsigned int elapsed_ms(struct timespec& start, struct timespec& end);
 
     private:
 
@@ -124,6 +125,9 @@ namespace FrameProcessor {
 
         /** Process raw mode **/
         uint32_t raw_mode_;
+
+        /** Record of idle packet timestamps **/
+        struct timespec idle_timestamp_;
 
         void dump_frame(boost::shared_ptr<Frame> frame);
 


### PR DESCRIPTION
Provide updates to allow successful completion of acquisitions in the case where some modules of the detector see little or no events.  Provide a mechanism for recognising the start of an acquisition, and ensure that the meta writer application fills time slice counters with 0 value entries if necessary to allow processing to work with the saved data files.